### PR TITLE
Create symlink for README.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,1 @@
+../flutter_line_liff/README.md


### PR DESCRIPTION
Fix the README file display issue in mono repo. It should support Github and Pub.dev at same time.